### PR TITLE
Use Gatekeeper test instance instead of local one

### DIFF
--- a/src/components/DatasetList/Home.vue
+++ b/src/components/DatasetList/Home.vue
@@ -78,10 +78,13 @@ export default {
   },
   methods: {
     ...mapActions('auth', ['refreshUser']),
+    /*
+     * TODO: Replace this with `login` from the authentication store
+     * once the environment variables are in place.
+     */
     login() {
-      // TODO: Replace hard coded URLs.
       const encodedRedirectURL = encodeURIComponent('http://localhost:8080')
-      window.location = `http://localhost:4554/login?redirect=${encodedRedirectURL}`
+      window.location = `https://gatekeeper.k8s-test.oslo.kommune.no/login?redirect=${encodedRedirectURL}`
     },
   },
 }

--- a/src/store/authentication.js
+++ b/src/store/authentication.js
@@ -42,7 +42,7 @@ export const actions = {
     try {
       const { data } = await axios.request({
         // TODO: Fetch this from an environment variable.
-        baseURL: 'http://localhost:4554',
+        baseURL: 'https://gatekeeper.k8s-test.oslo.kommune.no',
         url: '/userinfo',
         method: 'get',
         withCredentials: true,
@@ -56,7 +56,7 @@ export const actions = {
             if (process.server) {
               // TODO: Fetch this from an environment variable
               console.error(
-                `Couldn't reach Gatekeeper on url http://localhost:4554`
+                `Couldn't reach Gatekeeper on url https://gatekeeper.k8s-test.oslo.kommune.no`
               )
             }
             throw error


### PR DESCRIPTION
Use the test instance of Gatekeeper on https://gatekeeper.k8s-test.oslo.kommune.no instead of relying on having it running locally.