### PR TITLE
DP-1280: Deploy to dev whenever a new image is built

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -48,3 +48,22 @@ jobs:
 
       - name: Push version bump
         run: git push --follow-tags
+
+  # Deploy service to dev
+  deploy:
+    name: Redeploy app
+    needs: push
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Deploy dataplatform-frontend on dev
+        run: |
+          aws ecs update-service --force-new-deployment --service dataplatform-frontend --cluster dataplatform-public

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Runtime environment is achieved by `entrypoint.sh`, which edits `index.html` whe
 
 Set variables like so: `docker run -e VUE_APP_BASE_URL=datasets.no -e OTHER_VARIABLE=42`
 
+## Deployment
+This application is deployed automatically to dev whenever a new version is pushed to [GHCR](https://github.blog/2020-09-01-introducing-github-container-registry/)
+
 ## Developer guide
 Core functionality like `isAuthenticated` and other Voodo magic.
 


### PR DESCRIPTION
This PR implements auto-deployment to dev by forcing the service to redeploy using the ecs update-service command. Relevant documentation is here: https://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html
