### PR TITLE
DP-1191: Deploy dataplatform-frontend to prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+
+jobs:
+    # Deploy service to prod
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Deploy dataplatform-frontend on prod
+        run: |
+          aws ecs update-service --force-new-deployment --service dataplatform-frontend --cluster dataplatform-public


### PR DESCRIPTION
Adds a manually-triggered workflow to facilitate redeploying the app to fargate, using the same method as #24 